### PR TITLE
Require API KEY to call api bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+LITCRYPT_ENCRYPT_KEY=myverysuperdupermegaultrasecretkey
+BOT_API_KEY=PermitidoHacerCosas123

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           submodules: recursive
       - uses: shuttle-hq/deploy-action@main
+        env:
+          LITCRYPT_ENCRYPT_KEY: ${{ secrets.LITCRYPT_ENCRYPT_KEY }}
+          BOT_API_KEY: ${{ secrets.BOT_API_KEY }}
         with:
           deploy-key: ${{ secrets.SHUTTLE_DEPLOY_KEY }}
           allow-dirty: "true"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,10 @@ dependencies = [
  "axum 0.7.5",
  "color-eyre",
  "gen_welcome",
+ "litcrypt2",
+ "once_cell",
  "parking_lot",
+ "regex",
  "reqwest 0.12.2",
  "scraper",
  "serde",
@@ -1471,6 +1474,18 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
+name = "litcrypt2"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4126aa57ac1b3dd20a5bc827a2972cdf74c619a4d6ae5660656408289e5bc60d"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "rand",
+]
 
 [[package]]
 name = "lock_api"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ regex = "1.10.2"
 once_cell = "1.18.0"
 
 gen_welcome = { version = "0.1.0", path = "crates/gen_welcome" }
+litcrypt2 = "0.1.2"
 
 [dependencies.parking_lot]
 version = "0.12"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Bot de la comunidad de Discord de RustLang en Español.
 
 ## Desarrollo
 
+> [!IMPORTANT]
+> Antes de compilar el proyecto necesitas definir algunas variables de entorno para que compile correctamente
+> las variables a definir las tienes en el archivo [`./.env.example`](./.env.example)
+
 Para ejecutar el código en modo desarrollo tienes dos opciones:
 
 1. Recarga automática al guardar un archivo usando `shuttle`:

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,14 @@ pub mod events;
 pub mod general_commands;
 pub mod slash_commands;
 use config::setup::setup;
+use once_cell::sync::Lazy;
 
-const BOT_API_KEY: &str = env!("BOT_API_KEY");
+#[macro_use]
+extern crate litcrypt2;
+
+use_litcrypt!();
+
+static BOT_API_KEY: Lazy<String> = Lazy::new(|| lc!(env!("BOT_API_KEY")));
 
 pub struct CustomService {
     discord_bot: Client,
@@ -50,7 +56,7 @@ async fn auth_token(headers: HeaderMap, req: Request, next: Next) -> Result<Resp
     if headers
         .get("Authorization")
         .as_ref()
-        .is_some_and(|k| k.to_str().unwrap() == BOT_API_KEY)
+        .is_some_and(|k| k.to_str().unwrap() == BOT_API_KEY.as_str())
     {
         return Ok(next.run(req).await);
     }


### PR DESCRIPTION
Se necesitan agregar los siguientes secrets:

- `LITCRYPT_ENCRYPT_KEY`: Seguridad extra para la ofuscacion del texto plano en el binario
- `BOT_API_KEY`: La API-KEY permitida para los clientes

**TODO:**
- [ ] Cambiar el worker de los retos diarios para agregar la API-KEY