### PR TITLE
Arreglar recursividad

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "shuttle-runtime",
  "songbird",
  "symphonia",
+ "time",
  "tokio",
  "tracing",
  "urlencoding",
@@ -3487,9 +3488,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -3508,9 +3509,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ once_cell = "1.18.0"
 gen_welcome = { version = "0.1.0", path = "crates/gen_welcome" }
 urlencoding = "2.1.3"
 lazy_static = "1.4.0"
+time = "0.3.36"
 
 [dependencies.parking_lot]
 version = "0.12"

--- a/src/events/read_github_links.rs
+++ b/src/events/read_github_links.rs
@@ -166,7 +166,7 @@ async fn read_message(link: String) -> Option<String> {
 #[async_trait]
 impl EventHandler for ReadGithubLinkHandler {
     async fn message(&self, ctx: Context, msg: Message) {
-        if msg.author.bot {
+        if msg.author.bot || msg.content.starts_with("noembed") {
             return;
         }
 

--- a/src/events/read_github_links.rs
+++ b/src/events/read_github_links.rs
@@ -166,6 +166,10 @@ async fn read_message(link: String) -> Option<String> {
 #[async_trait]
 impl EventHandler for ReadGithubLinkHandler {
     async fn message(&self, ctx: Context, msg: Message) {
+        if msg.author.bot {
+            return;
+        }
+
         let repo_regex
             = Regex::new(r"(https://github\.com/(?:[^/]+/){2})blob/(.*)")
             .unwrap();


### PR DESCRIPTION
# Descripción

Este PR arregla un problema de recursividad al leer los enlaces, donde el bot también leía sus propios mensajes, ahora tiene una restricción en donde si el autor del mensaje es un bot simplemente no envía ningún embed.

Como extra también añade otra condición en donde si el mensaje empieza por `noembed` el bot no mandará ningún embed leyendo ningún archivo.

```rust
if msg.author.bot || msg.content.starts_with("noembed") {
    return;
}
```

El bot añade una librería que aparentemente no se usa, pero es usada por otra librería, esta librería tenía una versión rota que no permite iniciar el bot, por lo que instalándola manualmente forzaba la versión a ser la última...

https://users.rust-lang.org/t/time-crate-compilation-error/111789