### PR TITLE
feat: compile replies and env documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Bot de la comunidad de Discord de RustLang en Español.
 
 ### 1. Modificar variables de entorno:
 
-Para que el bot se ejecute tenemos que crear el archivo `Secret.toml` con sus respectivas variables:
+Para que el bot se ejecute tenemos que crear el archivo `Secrets.toml` con sus respectivas variables:
 
 - `DISCORD_TOKEN` Token del bot
 - `GUILD_ID` Id del Servidor

--- a/src/bot/events/compile.rs
+++ b/src/bot/events/compile.rs
@@ -149,13 +149,18 @@ pub async fn message(ctx: &Context, msg: &Message) -> Result<bool, bot::Error> {
         return Ok(false);
     }
 
+    let content = match &msg.referenced_message {
+        Some(reference) => &format!("&compile\n{}", &reference.content),
+        None => &msg.content
+    };
+
     msg.react(ctx, ReactionType::Unicode("🫡".to_string()))
         .await
         .unwrap();
 
     let parts: Vec<&str> = Regex::new(r"[ \n]")
         .unwrap()
-        .splitn(&msg.content, 2)
+        .splitn(&content, 2)
         .collect();
 
     if parts.len() < 2 {
@@ -216,7 +221,7 @@ pub async fn message(ctx: &Context, msg: &Message) -> Result<bool, bot::Error> {
         return Ok(true);
     }
 
-    if !msg.content.contains("--no-main") {
+    if !content.contains("--no-main") {
         let template = MAIN_TEMPLATES
             .iter()
             .find(|&&(lang, _)| lang == language)
@@ -234,7 +239,7 @@ pub async fn message(ctx: &Context, msg: &Message) -> Result<bool, bot::Error> {
         }
     }
 
-    if msg.content.contains("--escape") {
+    if content.contains("--escape") {
         code_block = code_block.replace(r"\`", "`");
     }
 


### PR DESCRIPTION
This PR aims to let users compile other users messages by simply responding to their message

It also adds documentation to the environment variables to start the bot.

The strategy was to simply check whether the message had a reference and when it did append `&compile` to it, then it processes the message as if it was your own.