### PR TITLE
feat: add delete button to github links responses and fix comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,6 @@ dependencies = [
  "chrono",
  "color-eyre",
  "gen_welcome",
- "lazy_static",
  "once_cell",
  "parking_lot",
  "poise",

--- a/src/bot/events.rs
+++ b/src/bot/events.rs
@@ -33,6 +33,14 @@ pub async fn handle(
         FullEvent::GuildMemberAddition { new_member } => {
             join::guild_member_addition(ctx, &GuildId::new(data.secrets.guild_id), new_member)
                 .await;
+        },
+        FullEvent::InteractionCreate { interaction } => {
+            // for buttons
+            if let Some (interaction) = interaction.as_message_component() {
+                if read_github_links::handle_delete_embed(ctx, interaction).await {
+    
+                }
+            }
         }
         _ => {}
     }


### PR DESCRIPTION
This PR fixes the GitHub comment templates being a static without a `OnceCell`, and it also adds a button that if you are the owner of the message that was replied by the bot to read the GitHub file, you can delete the message.

![image](https://github.com/user-attachments/assets/f9a87369-912c-42b0-a573-79e9ce506475)
