### PR TITLE
feat: save github embeds

### DIFF
--- a/src/bot/events.rs
+++ b/src/bot/events.rs
@@ -37,8 +37,11 @@ pub async fn handle(
         FullEvent::InteractionCreate { interaction } => {
             // for buttons
             if let Some (interaction) = interaction.as_message_component() {
-                if read_github_links::handle_delete_embed(ctx, interaction).await {
-    
+                if
+                    read_github_links::handle_delete_embed(ctx, interaction).await
+                    || read_github_links::handle_save_embed(ctx, interaction).await
+                {
+                    return Ok(());
                 }
             }
         }


### PR DESCRIPTION
This PR adds the ability for the user to save GitHub embeds (aka GitHub read link replies) to their MD's, by adding a button below the embed, everyone can save any embed no mater the author.