### PR TITLE
chore: add build.rs to ensure submodule initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ Bot de la comunidad de Discord de RustLang en Español.
 
 Las variables de entorno necesarias están documentadas en [`doc/VARIABLES.md`](doc/VARIABLES.md). Asegúrate de configurarlas antes de ejecutar el bot.
 
-### 2. Ejecutar el bot
+### 2. Gestión de Submódulos
+
+Para gestionar los submódulos del proyecto, consulta la documentación en [`doc/SUBMODULOS.md`](doc/SUBMODULOS.md).
+
+### 3. Ejecutar el bot
 
 Luego ejecuta el siguiente comando para ejecutar de modo local el bot:
 ```bash

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ fn main() {
         if !std::process::Command::new("git")
             .args(["submodule", "update", "--init", "--recursive"])
             .status()
-            .expect("Fallo al ejecutar git submodule update")
+            .expect("Failed to execute git submodule update")
             .success()
         {
             panic!("Submodule update failed. Run: git submodule update --init --recursive");

--- a/build.rs
+++ b/build.rs
@@ -1,20 +1,14 @@
 // dep-installer-hack/build.rs
 
 fn main() {
-    // Install external dependency (in the shuttle container only)
-    if std::env::var("HOSTNAME")
-        .unwrap_or_default()
-        .contains("shuttle")
-        && !std::process::Command::new("apt")
-            .arg("install")
-            .arg("-y")
-            .arg("libopus-dev") // the apt package that a dependency of my project needs to compile
-            .arg("ffmpeg") // the apt package that a dependency of my project needs to compile
-            // can add more here
-            .status()
-            .expect("failed to run apt")
-            .success()
+    println!("cargo:rerun-if-changed=static/rust-examples");
+
+    if !std::process::Command::new("git")
+        .args(["submodule", "update", "--init", "--recursive"])
+        .status()
+        .expect("Fallo al ejecutar git submodule update")
+        .success()
     {
-        panic!("failed to install dependencies")
+        panic!("Submodule update failed. Run: git submodule update --init --recursive");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,7 @@
 // dep-installer-hack/build.rs
 
 fn main() {
-    println!("cargo:rerun-if-env-changed=SUBMOD");
-    if std::env::var("SUBMOD").is_ok() {
-        println!("cargo:rerun-if-changed=static/rust-examples");
+    if !std::path::Path::new("static/rust-examples/docs").exists() {
         if !std::process::Command::new("git")
             .args(["submodule", "update", "--init", "--recursive"])
             .status()

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,16 @@
 // dep-installer-hack/build.rs
 
 fn main() {
-    println!("cargo:rerun-if-changed=static/rust-examples");
-
-    if !std::process::Command::new("git")
-        .args(["submodule", "update", "--init", "--recursive"])
-        .status()
-        .expect("Fallo al ejecutar git submodule update")
-        .success()
-    {
-        panic!("Submodule update failed. Run: git submodule update --init --recursive");
+    println!("cargo:rerun-if-env-changed=SUBMOD");
+    if std::env::var("SUBMOD").is_ok() {
+        println!("cargo:rerun-if-changed=static/rust-examples");
+        if !std::process::Command::new("git")
+            .args(["submodule", "update", "--init", "--recursive"])
+            .status()
+            .expect("Fallo al ejecutar git submodule update")
+            .success()
+        {
+            panic!("Submodule update failed. Run: git submodule update --init --recursive");
+        }
     }
 }

--- a/doc/SUBMODULOS.md
+++ b/doc/SUBMODULOS.md
@@ -1,0 +1,52 @@
+# Gestión de Submódulos en Cangrebot
+
+## Introducción
+
+Este proyecto utiliza submódulos de Git para gestionar dependencias externas dentro del repositorio. Un submódulo es un repositorio dentro de otro repositorio, lo que permite incluir código de terceros sin mezclarlo directamente con el código principal.
+
+## Inicialización y Actualización de Submódulos
+
+Si has clonado el repositorio y el submódulo no aparece, debes inicializarlo y actualizarlo manualmente con el siguiente comando:
+
+```sh
+ git submodule update --init --recursive
+```
+
+Esto descargará el contenido del submódulo y lo sincronizará con la versión esperada en el repositorio principal.
+
+## Automatización con `build.rs`
+
+Para evitar la necesidad de ejecutar este comando manualmente, el proyecto incluye un `build.rs` que se encarga de actualizar automáticamente el submódulo si la variable de entorno `SUBMOD` está activada:
+
+```sh
+SUBMOD=1 cargo build
+```
+
+Si esta variable no está presente, el submódulo no se actualizará automáticamente.
+
+También puedes hacer que `SUBMOD=1` se use siempre en `build.rs` sin necesidad de pasarla manualmente. Para ello, agrégalo en `.cargo/config.toml`:
+
+```toml
+[env]
+SUBMOD = "1"
+```
+
+## Verificación del Estado del Submódulo
+
+Puedes verificar el estado del submódulo con:
+
+```sh
+git submodule status
+```
+
+Esto mostrará si el submódulo está correctamente sincronizado o si requiere una actualización.
+
+## Consideraciones
+
+- Si trabajas en una rama donde el submódulo ha cambiado, ejecuta `git submodule update --remote` para traer la última versión.
+- Al clonar un nuevo repositorio, recuerda siempre inicializar y actualizar los submódulos.
+
+## Conclusión
+
+El uso de submódulos permite gestionar dependencias de manera eficiente sin mezclar código externo en el repositorio principal. Con la automatización en `build.rs`, se puede reducir la fricción al compilar el proyecto en diferentes entornos.
+

--- a/doc/SUBMODULOS.md
+++ b/doc/SUBMODULOS.md
@@ -14,22 +14,8 @@ Si has clonado el repositorio y el submódulo no aparece, debes inicializarlo y 
 
 Esto descargará el contenido del submódulo y lo sincronizará con la versión esperada en el repositorio principal.
 
-## Automatización con `build.rs`
+> El archivo `build.rs` detectará automáticamente si el submódulo existe. Si no está inicializado, mostrará un mensaje indicando que es necesario ejecutar: `git submodule update --init --recursive`
 
-Para evitar la necesidad de ejecutar este comando manualmente, el proyecto incluye un `build.rs` que se encarga de actualizar automáticamente el submódulo si la variable de entorno `SUBMOD` está activada:
-
-```sh
-SUBMOD=1 cargo build
-```
-
-Si esta variable no está presente, el submódulo no se actualizará automáticamente.
-
-También puedes hacer que `SUBMOD=1` se use siempre en `build.rs` sin necesidad de pasarla manualmente. Para ello, agrégalo en `.cargo/config.toml`:
-
-```toml
-[env]
-SUBMOD = "1"
-```
 
 ## Verificación del Estado del Submódulo
 
@@ -48,5 +34,5 @@ Esto mostrará si el submódulo está correctamente sincronizado o si requiere u
 
 ## Conclusión
 
-El uso de submódulos permite gestionar dependencias de manera eficiente sin mezclar código externo en el repositorio principal. Con la automatización en `build.rs`, se puede reducir la fricción al compilar el proyecto en diferentes entornos.
-
+El uso de submódulos permite gestionar dependencias de manera eficiente sin mezclar código externo en el repositorio principal. 
+Con la automatización en `build.rs`, se puede reducir la fricción al compilar el proyecto sin necesidad de pasos adicionales


### PR DESCRIPTION
Me di cuenta de que el submódulo no aparecía inicialmente, así que agregué un build.rs para ejecutarlo automáticamente con `git submodule update --init --recursive`. Esto evita la necesidad de hacerlo manualmente.