### PR TITLE
Adding "github action workflow" to deploy a rust project and i improve a little the documentation of the project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,7 @@ GUILD_ID = "Server ID"
 
 # Config
 CHANNEL_DAILY = "Channel id for Daily Challenges"
-LAVALINK_HOST = "Hostname with Port"
-LAVALINK_PASSWORD = "Lavalink Password"
+CHANNEL_SUGGEST = "Channel id for Channel Suggest"
 
 # Keep this for development
 BOT_APIKEY = "PermitidoHacerCosas123"

--- a/.github/workflows/rust-build-deploy.yml
+++ b/.github/workflows/rust-build-deploy.yml
@@ -1,0 +1,47 @@
+name: Build and Deploy Rust Binary
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      REMOTE_USER: ${{ secrets.REMOTE_USER }}
+      REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
+      REMOTE_PATH: ${{ secrets.REMOTE_PATH }}
+      PROGRAM_NAME: ${{ secrets.PROGRAM_NAME }}
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build project
+        run: cargo build --release
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 400 ~/.ssh/id_rsa
+          ssh-keyscan -H $REMOTE_HOST >> ~/.ssh/known_hosts
+          echo "${{ secrets.KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Kill existing process
+        run: |
+          ssh $REMOTE_USER@$REMOTE_HOST "pgrep -f $PROGRAM_NAME && pkill -f $PROGRAM_NAME || echo 'No process to kill'" || true
+
+      - name: Copy binary to remote server
+        run: scp target/release/$PROGRAM_NAME $REMOTE_USER@$REMOTE_HOST:$REMOTE_PATH
+
+      - name: Set binary as executable
+        run: ssh $REMOTE_USER@$REMOTE_HOST "chmod +x $REMOTE_PATH/$PROGRAM_NAME"
+
+      - name: Launch new process
+        run: ssh $REMOTE_USER@$REMOTE_HOST "nohup $REMOTE_PATH/$PROGRAM_NAME > /dev/null 2>&1 &"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,39 @@ Luego ejecuta el siguiente comando para ejecutar de modo local el bot:
 ```bash
 cargo run
 ```
+## Configuración de Variables Secretas para GitHub Actions
+
+Para que el flujo de trabajo de GitHub Actions funcione correctamente, es necesario configurar las siguientes variables secretas en el repositorio. Estas variables se utilizan para la autenticación y despliegue del binario Rust en el servidor remoto.
+
+### Variables necesarias
+
+1. **`REMOTE_USER`**: El nombre de usuario para acceder al servidor remoto.
+2. **`REMOTE_HOST`**: La dirección IP o el nombre de host del servidor remoto.
+3. **`REMOTE_PATH`**: La ruta en el servidor remoto donde se copiará el binario.
+4. **`PROGRAM_NAME`**: El nombre del binario generado por el proyecto Rust.
+5. **`SSH_PRIVATE_KEY`**: La clave privada SSH para autenticarte en el servidor remoto.
+6. **`KNOWN_HOSTS`**: La lista de hosts conocidos para evitar advertencias de autenticidad SSH.
+
+### Pasos para configurar las variables para el despliege en github actions
+
+1. Ve a la página del repositorio en GitHub.
+2. Haz clic en la pestaña **Settings**.
+3. En el menú lateral, selecciona **Secrets and variables** > **Actions**.
+4. Haz clic en el botón **New repository secret** para agregar cada una de las variables mencionadas anteriormente.
+5. Ingresa el nombre de la variable (por ejemplo, `REMOTE_USER`) y su valor correspondiente.
+6. Repite este proceso para todas las variables necesarias.
+
+### Ejemplo de configuración
+
+Si estás desplegando un proyecto llamado `my-rust-app`, las variables podrían configurarse de la siguiente manera:
+
+- `REMOTE_USER`: `deploy_user`
+- `REMOTE_HOST`: `192.168.1.100`
+- `REMOTE_PATH`: `/home/deploy_user/apps`
+- `PROGRAM_NAME`: `my-rust-app`
+- `SSH_PRIVATE_KEY`: (contenido de tu clave privada SSH)
+
+Una vez configuradas las variables, el flujo de trabajo de GitHub Actions se encargará de construir y desplegar automáticamente el binario Rust en el servidor remoto al hacer un push a la rama `main`.
 
 ## Autores
 


### PR DESCRIPTION
adding "github action workflow" to deploy a rust project, using ssh, also i remove unused envariment variables of .env.example, and add the CHANNEL_SUGGEST, that is required to start the cangrebot, btw i added to README.md the variables that we need add in github sectret to using that workflow