### PR TITLE
fix/voices of the void

### DIFF
--- a/src/bot/commands/tts/begin.rs
+++ b/src/bot/commands/tts/begin.rs
@@ -14,7 +14,7 @@ pub async fn begin(ctx: bot::Context<'_>, user: Option<UserId>) -> Result<(), bo
         ctx.data().tts.join(ctx.channel_id()).await;
     }
 
-    if ctx.data().tts.check_same_channel(&ctx).await? {
+    if !ctx.data().tts.check_same_channel(&ctx).await? {
         return Ok(());
     };
 

--- a/src/bot/commands/tts/end.rs
+++ b/src/bot/commands/tts/end.rs
@@ -6,7 +6,7 @@ use crate::bot::commands::TtsStateExt;
 
 #[poise::command(slash_command, prefix_command, guild_only)]
 pub async fn end(ctx: bot::Context<'_>, user: Option<UserId>) -> Result<(), bot::Error> {
-    if ctx.data().tts.check_same_channel(&ctx).await? {
+    if !ctx.data().tts.check_same_channel(&ctx).await? {
         return Ok(());
     };
 

--- a/src/bot/commands/tts/leave.rs
+++ b/src/bot/commands/tts/leave.rs
@@ -8,7 +8,7 @@ pub async fn leave(ctx: bot::Context<'_>) -> Result<(), bot::Error> {
     let guild_id = ctx.guild().ok_or("No se pudo obtener el guild")?.id;
     let tts = &ctx.data().tts;
 
-    if tts.check_same_channel(&ctx).await? {
+    if !tts.check_same_channel(&ctx).await? {
         return Ok(());
     }
 

--- a/src/bot/commands/tts/mod.rs
+++ b/src/bot/commands/tts/mod.rs
@@ -102,6 +102,7 @@ pub trait TtsStateExt {
     async fn active_users(&self) -> usize;
     async fn begin(&self, user_id: UserId);
     async fn end(&self, user_id: &UserId) -> bool;
+    async fn reset(&self);
     async fn is_active_user(&self, user_id: &UserId) -> bool;
     async fn join(&self, channel: ChannelId);
     async fn leave(&self, ctx: &serenity::Context, guild_id: GuildId) -> Result<(), bot::Error>;
@@ -123,6 +124,10 @@ impl TtsStateExt for Mutex<TtsState> {
 
     async fn end(&self, user_id: &UserId) -> bool {
         self.lock().await.end(user_id)
+    }
+
+    async fn reset(&self) {
+        self.lock().await.reset()
     }
 
     async fn is_active_user(&self, user_id: &UserId) -> bool {
@@ -149,6 +154,10 @@ pub struct TtsState {
 }
 
 impl TtsState {
+    pub fn active_channel(&self) -> Option<&ChannelId> {
+        self.active_channel.as_ref()
+    }
+
     pub fn reset(&mut self) {
         self.active_users.clear();
         _ = self.active_channel.take();

--- a/src/bot/commands/tts/mod.rs
+++ b/src/bot/commands/tts/mod.rs
@@ -186,7 +186,7 @@ impl TtsState {
         self.active_users.contains(user_id)
     }
 
-    // Returns true if needs to early return
+    // Returns false if needs to early return
     pub async fn check_same_channel(&self, ctx: &bot::Context<'_>) -> Result<bool, bot::Error> {
         let Some(call_channel) = self.active_channel else {
             ctx.send(
@@ -198,14 +198,14 @@ impl TtsState {
             )
             .await?;
 
-            return Ok(true);
+            return Ok(false);
         };
 
         if ctx.channel_id() != call_channel {
             ctx.reply("Permitido solo en el canal de voz donde me encuentro.")
                 .await?;
 
-            return Ok(true);
+            return Ok(false);
         }
 
         let member = ctx.author_member().await.ok_or("Failed to get member")?;
@@ -220,8 +220,8 @@ impl TtsState {
             .user_permissions_in(&guild_channel, member.as_ref());
 
         // Moderators bypass
-        if !perms.manage_messages() {
-            return Ok(false);
+        if perms.manage_messages() {
+            return Ok(true);
         }
 
         let is_on_same_vc = ctx
@@ -236,14 +236,14 @@ impl TtsState {
             ctx.reply("Tienes que estar conectado en vc para utilizar este comando.")
                 .await?;
 
-            return Ok(true);
+            return Ok(false);
         }
 
-        Ok(false)
+        Ok(true)
     }
 
     pub async fn join_vc(
-        ctx: &poise::serenity_prelude::Context,
+        ctx: &serenity::Context,
         guild_id: GuildId,
         channel_id: ChannelId,
     ) -> Result<bool, bot::Error> {

--- a/src/bot/commands/tts/skip.rs
+++ b/src/bot/commands/tts/skip.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 pub async fn skip(ctx: bot::Context<'_>) -> Result<(), bot::Error> {
     let guild_id = ctx.guild().ok_or("No se pudo obtener el guild")?.id;
 
-    if ctx.data().tts.check_same_channel(&ctx).await? {
+    if !ctx.data().tts.check_same_channel(&ctx).await? {
         return Ok(());
     }
 

--- a/src/bot/commands/tts/tts.rs
+++ b/src/bot/commands/tts/tts.rs
@@ -15,7 +15,7 @@ async fn tts_play(ctx: bot::Context<'_>, text: String) -> Result<(), bot::Error>
         ctx.data().tts.join(ctx.channel_id()).await;
     }
 
-    if ctx.data().tts.check_same_channel(&ctx).await? {
+    if !ctx.data().tts.check_same_channel(&ctx).await? {
         return Ok(());
     }
 


### PR DESCRIPTION
Fix some tweaks that bugs the bot's tts.

Changes:
- **fix(tts): Allow channel check bypass by moderators**
- **fix(tts): change priority on channel check bypass**
Now the moderators can remote control the bot without any check.

- **fix(tts): handle forced move or disconnect**
Update the internal tts state when someone (@Phosphorus-M) forces the bot vc.
