### PR TITLE
fix(tts): link's regex

### DIFF
--- a/src/bot/commands/tts/tts_regex.rs
+++ b/src/bot/commands/tts/tts_regex.rs
@@ -1,5 +1,6 @@
 pub const MENTION_REGEX: &str = r"<@(\d+)>";
-pub const LINK_REGEX: &str = r"<?https?://(?:www\.)?[-a-zA-Z0-9@%._+~#=]{2,256}\.[a-z]{2,6}(?:[-a-zA-Z0-9@:%_+.~#?&/=\p{L}]*)>?";
+// regex struct -> http.://(subdomain-and-sld).(tld)(path, url query, etc... )
+pub const LINK_REGEX: &str = r"<?https?://[[[:word:]]-@%.+~#=]{2,256}\.[[:alnum:]]{2,24}(?:[-[[:word:]]@:%+.~#?&/=\p{L}]*)>?";
 pub const EMOJI_REGEX: &str = r"<a?:([a-zA-Z0-9_]+):\d+>";
 pub const LAUGHTER_REGEX: &str = r"(?i)\b[jsadkf]{4,}\b";
 pub const WHAT_REGEX: &str = r"(?i)\bq\b";
@@ -9,3 +10,55 @@ pub const INLINE_CODE_BLOCK_REGEX: &str = r"`([^`\n]+)`";
 pub const MULTI_LINE_DOUBLE_CODE_BLOCK_REGEX: &str = r"``([^`\n]+)``";
 pub const MULTI_LINE_TRIPLE_CODE_BLOCK_REGEX: &str = r"```([\s\S]*?)```";
 pub const CORRECTION_REGEX: &str = r"^\w+\*$";
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    fn aux_match(regex: &str,haystack: &str) -> bool {
+        match Regex::new(regex) {
+            Ok(re) => re.is_match(haystack),
+            Err(_) => false,
+        }
+    }
+
+
+    #[test]
+    fn regex_definition() {
+        assert!(Regex::new(LINK_REGEX).is_ok());
+    }
+
+    #[test]
+    fn links_matchs() {
+        let cases  = [
+            "http://b32.i2p/",
+            "http://a..xyz",
+            "http://a..xyz",
+            "http://...xyz",
+            "<http://rustlang-es.org/",
+            "http://rustlang-es.org/>",
+            "https://rustlang-es.org/",
+            "https://book.rustlang-es.org",
+            "https://www.rustlang-es.org",
+            "http://hi.xn--4gbrim/",
+            "https://stackoverflow.com/questions/9238640/how-long-can-a-tld-possibly-be#:~:text=This%20answer%20is%20useful,to%20count%20the%20longest%20line"
+        ];
+        for case in cases {
+            assert!(aux_match(LINK_REGEX, case));
+        }
+    }
+
+    #[test]
+    fn links_not_matchs() {
+        let cases  = [
+            "ftp://b32.i2p/",
+            "https://grüße.tld",
+            "https://example.موقع"
+        ];
+        for case in cases {
+            assert!(! aux_match(LINK_REGEX, case));
+        }
+    }
+}


### PR DESCRIPTION
resolve #95 

Agregando un poco de semántica a la regex y algunos test, no es la más robusta, pero sigue funcionando.
Cambie la longitud del TLD, porque según internet es más largo que existe y está activo tiene un longitud de 24 caracteres, teóricamente podrían tener una longitud de 63 pero no existe ninguno...
Como anotaciones de estilo más que funcionalidad:
- Estás regex se pueden re-escribir de manera menos verbosa.

```rs
  pub const MULTI_LINE_TRIPLE_CODE_BLOCK_REGEX: &str = r"```(.*?)```";
  pub const EMOJI_REGEX: &str = r"<a?:([[:word]]+):\d+>";
```


- Se puede simplificar la lógica en [mod.rs](https://github.com/RustLangES/cangrebot/blob/4269d8fb0d76e47d7a8adaf423b5499d88438120/src/bot/commands/tts/mod.rs#L318-L324) 

con un 
```rs
  pub const CODE_BLOCK_REGEX: &str  = r"INLINE_CODE_BLOCK_REGEX|MULTI_LINE_DOUBLE_CODE_BLOCK_REGEX|MULTI_LINE_TRIPLE_CODE_BLOCK_REGEX";
  ```

y mover los test de [tts.rs](https://github.com/RustLangES/cangrebot/blob/4269d8fb0d76e47d7a8adaf423b5499d88438120/src/bot/commands/tts/tts.rs#L90-L162) a [regex.rs](https://github.com/RustLangES/cangrebot/blob/main/src/bot/commands/tts/tts_regex.rs), pues no se está testeando del todo la regex y la "funcionalidad" que prueba (saber si tiene más 16 caractares) no sé está usando en ese lugar sino en mod.rs... 

btw esto sé hizo con el único fin que quitarle chamba a @MarioYellowy