### PR TITLE
refactor: use sort_by_key for message timestamps

### DIFF
--- a/src/bot/commands/stats.rs
+++ b/src/bot/commands/stats.rs
@@ -39,7 +39,7 @@ pub async fn send_stats(ctx: Context<'_>) -> Result<(), Error> {
         }
     }
     // Ordenar de más nuevo a más viejo y quedarnos con los 100 primeros
-    all_messages.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    all_messages.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
     let latest_100 = all_messages.into_iter().take(100).collect::<Vec<_>>();
 
     let serialized_msgs: Vec<Value> = latest_100


### PR DESCRIPTION
## Descripción

Reemplaza `sort_by` por `sort_by_key` al ordenar mensajes por timestamp, siguiendo la recomendación de Clippy.

## Cambios realizados

- Se actualizó el ordenamiento de mensajes en `send_stats`.
- Se usa `std::cmp::Reverse` para mantener el orden descendente, de más nuevo a más viejo.

## Verificación

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo check`

Este cambio corrige una recomendación de Clippy detectada durante el CI, reemplazando `sort_by` por `sort_by_key`.